### PR TITLE
Add missing <string> include to use std::string

### DIFF
--- a/ECSUtil/stdafx.h
+++ b/ECSUtil/stdafx.h
@@ -56,6 +56,7 @@
 //#include <ntdef.h>
 #include <WinNT.h>
 #include <memory>
+#include <string>
 #include <vector>
 #include <map>
 #include <list>


### PR DESCRIPTION
This causes compile failures with VS2019 previews, where \<vector> no longer includes \<string>.